### PR TITLE
add no fork option to flagged()

### DIFF
--- a/flor/complete_capture/trace_generator/log_stmts/client_root.py
+++ b/flor/complete_capture/trace_generator/log_stmts/client_root.py
@@ -4,7 +4,7 @@ import ast
 
 HEADER = """
 from flor import Flog
-if Flog.flagged(): flog = Flog(False)
+if Flog.flagged(option='nofork'): flog = Flog(False)
 """
 
 class ClientRoot(LogStmt):

--- a/flor/complete_capture/trace_generator/log_stmts/except_handler.py
+++ b/flor/complete_capture/trace_generator/log_stmts/except_handler.py
@@ -4,7 +4,7 @@ import ast
 
 HEADER = """
 from flor import Flog
-if Flog.flagged(): flog = Flog()
+if Flog.flagged(option='nofork'): flog = Flog()
 from inspect import stack as stackkcats
 """
 

--- a/flor/complete_capture/trace_generator/log_stmts/func_def.py
+++ b/flor/complete_capture/trace_generator/log_stmts/func_def.py
@@ -4,7 +4,7 @@ import ast
 
 HEADER = """
 from flor import Flog
-if Flog.flagged(): flog = Flog()
+if Flog.flagged(option='nofork'): flog = Flog()
 """
 
 class FuncDef(LogStmt):

--- a/flor/face_library/flog.py
+++ b/flor/face_library/flog.py
@@ -70,5 +70,7 @@ class Flog:
         return os.path.join(FLOR_DIR, name, 'log.json')
 
     @staticmethod
-    def flagged():
+    def flagged(option: str = None):
+        if option == 'nofork':
+            return not not os.listdir(FLOR_CUR)
         return not not os.listdir(FLOR_CUR)


### PR DESCRIPTION
No fork option resolves the `flog not found` error in multiprocessing.