### PR TITLE
Fix Pytorch bugs

### DIFF
--- a/flor/complete_capture/florify.py
+++ b/flor/complete_capture/florify.py
@@ -5,5 +5,5 @@ if __name__ == "__main__":
     Warning: Walker overwrites the path that you give it. Don't try this on your anaconda environment
     """
     #pass
-    walker = Walker('/Users/eliu/anaconda3/envs/flor/lib/python3.7/site-packages/tensorflow')
+    walker = Walker('/Users/eliu/anaconda3/envs/flor/lib/python3.7/site-packages/scipy')
     walker.compile_tree()

--- a/flor/complete_capture/florify.py
+++ b/flor/complete_capture/florify.py
@@ -5,5 +5,5 @@ if __name__ == "__main__":
     Warning: Walker overwrites the path that you give it. Don't try this on your anaconda environment
     """
     #pass
-    walker = Walker('/anaconda3/envs/flor/lib/python3.6/site-packages/torchvision')
+    walker = Walker('/Users/eliu/anaconda3/envs/flor/lib/python3.7/site-packages/tensorflow')
     walker.compile_tree()

--- a/flor/complete_capture/florify.py
+++ b/flor/complete_capture/florify.py
@@ -5,5 +5,5 @@ if __name__ == "__main__":
     Warning: Walker overwrites the path that you give it. Don't try this on your anaconda environment
     """
     #pass
-    walker = Walker('/anaconda3/envs/flor/lib/python3.6/site-packages/torchvision')
+    walker = Walker('/anaconda3/envs/flor/lib/python3.6/site-packages/torch')
     walker.compile_tree()

--- a/flor/complete_capture/florify.py
+++ b/flor/complete_capture/florify.py
@@ -4,6 +4,6 @@ if __name__ == "__main__":
     """
     Warning: Walker overwrites the path that you give it. Don't try this on your anaconda environment
     """
-    pass
-    # walker = Walker('/anaconda3/envs/flor/lib/python3.7/site-packages/sklearn.backup')
-    # walker.compile_tree()
+    #pass
+    walker = Walker('/anaconda3/envs/flor/lib/python3.6/site-packages/torchvision')
+    walker.compile_tree()

--- a/flor/complete_capture/florify.py
+++ b/flor/complete_capture/florify.py
@@ -5,5 +5,5 @@ if __name__ == "__main__":
     Warning: Walker overwrites the path that you give it. Don't try this on your anaconda environment
     """
     #pass
-    walker = Walker('/anaconda3/envs/flor/lib/python3.6/site-packages/torch')
+    walker = Walker('/anaconda3/envs/flor/lib/python3.6/site-packages/torchvision')
     walker.compile_tree()

--- a/flor/complete_capture/trace_generator/__init__.py
+++ b/flor/complete_capture/trace_generator/__init__.py
@@ -5,6 +5,7 @@ from flor.complete_capture.trace_generator.log_stmts.ret_val import Return, Yiel
 from flor.complete_capture.trace_generator.log_stmts.func_def import FuncDef
 from flor.complete_capture.trace_generator.log_stmts.loop import Loop
 from flor.complete_capture.trace_generator.log_stmts.client_root import ClientRoot
+from flor.complete_capture.trace_generator.log_stmts.lib_root import LibRoot
 from flor.complete_capture.trace_generator.log_stmts.except_handler import ExceptHandler
 __all__ = ['Assign', 'BoolExp', 'Raise', 'Return', 'Yield', 'FuncDef', 'Loop',
-           'ClientRoot', 'ExceptHandler']
+           'ClientRoot', 'LibRoot', 'ExceptHandler']

--- a/flor/complete_capture/trace_generator/log_stmts/client_root.py
+++ b/flor/complete_capture/trace_generator/log_stmts/client_root.py
@@ -3,7 +3,6 @@ from .. import util as gen
 import ast
 
 HEADER = """
-from flor import Flog
 if Flog.flagged(option='nofork'): flog = Flog(False)
 """
 

--- a/flor/complete_capture/trace_generator/log_stmts/except_handler.py
+++ b/flor/complete_capture/trace_generator/log_stmts/except_handler.py
@@ -3,7 +3,6 @@ from .. import util as gen
 import ast
 
 HEADER = """
-from flor import Flog
 if Flog.flagged(option='nofork'): flog = Flog()
 from inspect import stack as stackkcats
 """

--- a/flor/complete_capture/trace_generator/log_stmts/func_def.py
+++ b/flor/complete_capture/trace_generator/log_stmts/func_def.py
@@ -3,7 +3,6 @@ from .. import util as gen
 import ast
 
 HEADER = """
-from flor import Flog
 if Flog.flagged(option='nofork'): flog = Flog()
 """
 

--- a/flor/complete_capture/trace_generator/log_stmts/lib_root.py
+++ b/flor/complete_capture/trace_generator/log_stmts/lib_root.py
@@ -4,10 +4,10 @@ import ast
 
 HEADER = """
 from flor import Flog
-if Flog.flagged(option='nofork'): flog = Flog(False)
 """
 
-class ClientRoot(LogStmt):
+
+class LibRoot(LogStmt):
 
     def __init__(self, filepath, counter):
         super().__init__()
@@ -20,6 +20,5 @@ class ClientRoot(LogStmt):
     def to_string_head(self):
         lsn = self.counter['value']
         self.counter['value'] += 1
-        return (HEADER + "\n" + super().to_string("{{'file_path': '{}', 'lsn': {}}}".format(self.filepath, lsn))
-                + "\n")
+        return HEADER
 

--- a/flor/complete_capture/transformer/transformer.py
+++ b/flor/complete_capture/transformer/transformer.py
@@ -22,7 +22,7 @@ class ClientTransformer(ast.NodeTransformer):
         return new_node
 
     def visit_FunctionDef(self, node):
-        if '_' != node.name[0:1] or node.name == '__init__':
+        if '__' != node.name[0:2] or node.name == '__init__':
             # ONLY WRAP PUBLIC METHODS TO AVOID STACK OVERFLOW
             prev = self.fd
             relative_counter = self.relative_counter['value']
@@ -150,7 +150,8 @@ class LibTransformer(ast.NodeTransformer):
 
     def visit_FunctionDef(self, node):
         # TODO: Relative counter needs more work
-        if '__' != node.name[0:1] or node.name == '__init__':
+        #this is still decorating a bunch fo things it's not supposed to...please figure this out.
+        if '__' != node.name[0:2] or node.name == '__init__':
             # ONLY WRAP PUBLIC METHODS TO AVOID STACK OVERFLOW
             #don't wrap methods decorated with @torch.jit.*
             if self.check_skip(node):

--- a/flor/complete_capture/transformer/transformer.py
+++ b/flor/complete_capture/transformer/transformer.py
@@ -139,7 +139,7 @@ class LibTransformer(ast.NodeTransformer):
 
     def visit_FunctionDef(self, node):
         # TODO: Relative counter needs more work
-        if '__' != node.name[0:2] or node.name == '__init__':
+        if '_' != node.name[0:1] or node.name == '__init__':
             # ONLY WRAP PUBLIC METHODS TO AVOID STACK OVERFLOW
             self.active = True
             prev = self.fd

--- a/flor/complete_capture/transformer/transformer.py
+++ b/flor/complete_capture/transformer/transformer.py
@@ -222,6 +222,12 @@ class LibTransformer(ast.NodeTransformer):
             for field, old_value in ast.iter_fields(node):
                 if isinstance(old_value, list):
                     for x in range(len(old_value)):
+                        if isinstance(old_value[x], ast.ImportFrom) and old_value[x].module == '__future__':
+                            x += 1
+                            while isinstance(old_value[x], ast.ImportFrom) and old_value[x].module == '__future__':
+                                x += 1
+                            old_value.insert(x, LibRoot(self.filepath, self.relative_counter).parse_heads()[0])
+                            return super().generic_visit(node)
                         if isinstance(old_value[x], ast.Import) or isinstance(old_value[x], ast.ImportFrom):
                             # maybe add code to insert flor imports at the end of all imports?
                             old_value.insert(x+1, LibRoot(self.filepath, self.relative_counter).parse_heads()[0])

--- a/flor/complete_capture/walker/walker.py
+++ b/flor/complete_capture/walker/walker.py
@@ -124,7 +124,7 @@ class Walker():
             j = os.path.join
             ROOT = 'site-packages'
 
-            KEEP_SET = {'sklearn',}
+            KEEP_SET = {'sklearn', 'torchvision'}
 
             abs_path = abs_path.split(os.path.sep)
             abs_path = (os.path.sep).join(abs_path[abs_path.index(ROOT) + 1 : ])
@@ -135,6 +135,23 @@ class Walker():
             for keep_element in KEEP_SET:
                 if keep_element == abs_path[0:len(keep_element)]: return True
             return False
+
+        def insert_import(data_str):
+            data_split = data_str.split("\n")
+            inserted = False
+
+            for i in range(len(data_split)):
+                if data_split[i] == '':
+                    continue
+                if not inserted and 'import' in data_split[i]:
+                    inserted =  True
+                    data_split.insert(i, 'from flor import Flog')
+                if '\n' not in data_split[i]:
+                    data_split[i] += '\n'
+
+            return "".join(data_split)
+
+
 
         for (src_root, dirs, files) in os.walk(self.rootpath):
             # SRC_ROOT: in terms of Conda-Cloned environment
@@ -157,7 +174,7 @@ class Walker():
                                 save_in_case = f.read()
                                 astree = ast.parse(save_in_case)
                         new_astree = transformer.visit(astree)
-                        to_source = astor.to_source(new_astree)
+                        to_source = insert_import(astor.to_source(new_astree))
 
                         # Conda symlinks --- no copy. We need to remove symlink first
                         try:

--- a/flor/complete_capture/walker/walker.py
+++ b/flor/complete_capture/walker/walker.py
@@ -124,7 +124,7 @@ class Walker():
             j = os.path.join
             ROOT = 'site-packages'
 
-            KEEP_SET = {'sklearn', 'torch', 'torchvision'}
+            KEEP_SET = {'sklearn', 'tensorflow', 'torch', 'torchvision'}
 
             abs_path = abs_path.split(os.path.sep)
             abs_path = (os.path.sep).join(abs_path[abs_path.index(ROOT) + 1 : ])
@@ -157,7 +157,10 @@ class Walker():
         for (src_root, dirs, files) in os.walk(self.rootpath):
             # SRC_ROOT: in terms of Conda-Cloned environment
             for file in files:
-                _, ext = os.path.splitext(file)
+                filename, ext = os.path.splitext(file)
+                # blacklist serialization files
+                if 'serialization' in filename:
+                    continue
                 if ext == '.py' and patch_keep(os.path.join(src_root, file)):
                     lib_code and print('transforming {}'.format(os.path.join(src_root, file)))
                     try:

--- a/flor/complete_capture/walker/walker.py
+++ b/flor/complete_capture/walker/walker.py
@@ -124,7 +124,7 @@ class Walker():
             j = os.path.join
             ROOT = 'site-packages'
 
-            KEEP_SET = {'sklearn', 'tensorflow', 'torch', 'torchvision'}
+            KEEP_SET = {'sklearn', 'scipy', 'tensorflow', 'torch', 'torchvision'}
 
             abs_path = abs_path.split(os.path.sep)
             abs_path = (os.path.sep).join(abs_path[abs_path.index(ROOT) + 1 : ])

--- a/flor/complete_capture/walker/walker.py
+++ b/flor/complete_capture/walker/walker.py
@@ -136,30 +136,12 @@ class Walker():
                 if keep_element == abs_path[0:len(keep_element)]: return True
             return False
 
-        def insert_import(data_str):
-            data_split = data_str.split("\n")
-            inserted = False
-
-            for i in range(len(data_split)):
-                if data_split[i] == '':
-                    continue
-                if not inserted and 'import' in data_split[i]:
-                    inserted = True
-                    data_split.insert(i+1, 'from flor import Flog\n')
-                if '\n' not in data_split[i]:
-                    data_split[i] += '\n'
-            if not inserted:
-                data_split.insert(0, 'from flor import Flog\n')
-            return "".join(data_split)
-
-
-
         for (src_root, dirs, files) in os.walk(self.rootpath):
             # SRC_ROOT: in terms of Conda-Cloned environment
             for file in files:
                 filename, ext = os.path.splitext(file)
-                # blacklist serialization files
-                if 'serialization' in filename:
+                # blacklist serialization file
+                if 'serialization' in filename in filename:
                     continue
                 if ext == '.py' and patch_keep(os.path.join(src_root, file)):
                     lib_code and print('transforming {}'.format(os.path.join(src_root, file)))

--- a/flor/complete_capture/walker/walker.py
+++ b/flor/complete_capture/walker/walker.py
@@ -124,7 +124,7 @@ class Walker():
             j = os.path.join
             ROOT = 'site-packages'
 
-            KEEP_SET = {'sklearn', 'torchvision'}
+            KEEP_SET = {'sklearn', 'torch', 'torchvision'}
 
             abs_path = abs_path.split(os.path.sep)
             abs_path = (os.path.sep).join(abs_path[abs_path.index(ROOT) + 1 : ])
@@ -175,7 +175,7 @@ class Walker():
                                 save_in_case = f.read()
                                 astree = ast.parse(save_in_case)
                         new_astree = transformer.visit(astree)
-                        to_source = insert_import(astor.to_source(new_astree))
+                        to_source = astor.to_source(new_astree)
 
                         # Conda symlinks --- no copy. We need to remove symlink first
                         try:

--- a/flor/complete_capture/walker/walker.py
+++ b/flor/complete_capture/walker/walker.py
@@ -144,11 +144,12 @@ class Walker():
                 if data_split[i] == '':
                     continue
                 if not inserted and 'import' in data_split[i]:
-                    inserted =  True
-                    data_split.insert(i, 'from flor import Flog')
+                    inserted = True
+                    data_split.insert(i+1, 'from flor import Flog\n')
                 if '\n' not in data_split[i]:
                     data_split[i] += '\n'
-
+            if not inserted:
+                data_split.insert(0, 'from flor import Flog\n')
             return "".join(data_split)
 
 

--- a/flor/face_library/flog.py
+++ b/flor/face_library/flog.py
@@ -17,6 +17,7 @@ class Flog:
     What behavior do we care about?
 
     """
+    serializing = False
 
     def __init__(self, init_in_func_ctx=True):
         """
@@ -57,11 +58,15 @@ class Flog:
             license = self.controller.get_license_to_serialize()
             if not license:
                 return "PASS"
+        if Flog.serializing:
+            return "ERROR: failed to serialize"
         try:
-
+            Flog.serializing = True
             out = str(cloudpickle.dumps(x))
+            Flog.serializing = False
             return out
         except:
+            Flog.serializing = False
             return "ERROR: failed to serialize"
 
     @staticmethod


### PR DESCRIPTION
Pytorch had been encountering a multitude of errors upon execution, first complaining about import statements, then disallowing any log statements in `@pytorch.jit` decorated functions, and finally returning stack overflow errors. Several files have been changed to patch these errors. 

We now blacklist all pytorch serialization functions in `walker.py`, detect serialization loops in `flog.py`, and import `flog` only at the tops of files in `transformer.py`.
