### PR TITLE
More context on execution & remove flor shell script on uninstall

### DIFF
--- a/flor/__main__.py
+++ b/flor/__main__.py
@@ -62,9 +62,27 @@ def uninstall(multiuser=False):
         _, dst_root = f.read().strip().split(',')
 
     conda_flor_env = dst_root.split('/')[-1]
+
+    # Remove Flor script from user shell config file
+    shells_list = ['.zshrc', '.bashrc', '.cshrc', '.kshrc', '.config/fish/config.fish']
+    for s in shells_list:
+        shell_config = os.path.join(os.path.expanduser('~'), s)
+        if os.path.exists(shell_config):
+            import fileinput
+            file = fileinput.input(shell_config, inplace=True)
+
+            for line in file:
+                if 'flor() {' in line:
+                    for _ in range(5):
+                        # skip this line and next 5 lines
+                        next(file, None)
+                else:
+                    print(line.strip())
+
     subprocess.call(['conda', 'remove', '--name', conda_flor_env, '--all'])
     subprocess.call((['pip', 'uninstall', 'pyflor']))
     os.remove(conda_map_path)
+
 
 def install(base_conda='base', conda_flor_env='flor', python_version='3.7', multiuser=False):
     def make_conda_map(d, base_env_path, env_path):

--- a/flor/logs_manipulator/open_log.py
+++ b/flor/logs_manipulator/open_log.py
@@ -1,7 +1,6 @@
 import datetime
 import json
 import re
-import time
 import uuid
 
 import git

--- a/flor/logs_manipulator/open_log.py
+++ b/flor/logs_manipulator/open_log.py
@@ -1,6 +1,7 @@
 import datetime
 import json
 import re
+import time
 import uuid
 
 import git
@@ -61,6 +62,41 @@ class OpenLog:
         import getpass
         user_id = getpass.getuser()
         to_write.append({'user_id': user_id})
+
+        # Reliable timestamp from network server
+        def get_ntp_time(host='time.nist.gov'):
+            # Adapted from https://www.mattcrampton.com/blog/query_an_ntp_server_from_python/
+            # and https://gist.github.com/guneysus/9f85ab77e1a11d0eebdb
+            import socket
+            from socket import AF_INET, SOCK_DGRAM
+            import struct
+            import time
+
+            port = 123
+            buf = 1024
+            address = (host, port)
+            msg = '\x1b' + 47 * '\0'
+
+            # reference time (in seconds since 1900-01-01 00:00:00)
+            time1970 = 2208988800  # 1970-01-01 00:00:00
+
+            # connect to server
+            client = socket.socket(AF_INET, SOCK_DGRAM)
+            client.sendto(msg.encode('utf-8'), address)
+            msg, address = client.recvfrom(buf)
+
+            if msg:
+                # timestamp: seconds since epoch
+                timestamp = struct.unpack('!12I', msg)[10]
+                timestamp -= time1970
+                local_time = time.ctime(timestamp).replace('  ', ' ')
+                utc_time = time.strftime('%a %b %d %X %Y %Z', time.gmtime(timestamp))
+                return timestamp, local_time, utc_time
+
+        timestamp, local_time, utc_time = get_ntp_time()
+        to_write.append({'timestamp': timestamp})
+        to_write.append({'local_time': local_time})
+        to_write.append({'UTC_time': utc_time})
 
         for x in to_write:
             log_file.write(json.dumps(x) + '\n')

--- a/flor/logs_manipulator/open_log.py
+++ b/flor/logs_manipulator/open_log.py
@@ -30,16 +30,15 @@ class OpenLog:
 
         # MAC address
         MAC_addr = {'MAC_address': ':'.join(re.findall('..?', '{:x}'.format(uuid.getnode())))}
-
-        to_write = [session_start, MAC_addr]
+        session_start.update(MAC_addr)
 
         # Get EC2 instance type
         try:
             ec2 = boto3.resource('ec2')
             for i in ec2.instances.all():
-                to_write.append({'EC2_instance_type': i.instance_type})
+                session_start.update({'EC2_instance_type': i.instance_type})
         except:
-            to_write.append({'EC2_instance_type': 'None'})
+            session_start.update({'EC2_instance_type': 'None'})
 
         # User info from Git
         class GitConfig(git.Repo):
@@ -54,13 +53,13 @@ class OpenLog:
         r = GitConfig().config_reader()
         user_name = r.get_value('user', 'name')
         user_email = r.get_value('user', 'email')
-        to_write.append({'git_user_name': user_name})
-        to_write.append({'git_user_email': user_email})
+        session_start.update({'git_user_name': user_name})
+        session_start.update({'git_user_email': user_email})
 
         # System's userid
         import getpass
         user_id = getpass.getuser()
-        to_write.append({'user_id': user_id})
+        session_start.update({'user_id': user_id})
 
         # Reliable timestamp from network server
         def get_ntp_time(host='time.nist.gov'):
@@ -93,12 +92,11 @@ class OpenLog:
                 return timestamp, local_time, utc_time
 
         timestamp, local_time, utc_time = get_ntp_time()
-        to_write.append({'timestamp': timestamp})
-        to_write.append({'local_time': local_time})
-        to_write.append({'UTC_time': utc_time})
+        session_start.update({'timestamp': timestamp})
+        session_start.update({'local_time': local_time})
+        session_start.update({'UTC_time': utc_time})
 
-        for x in to_write:
-            log_file.write(json.dumps(x) + '\n')
+        log_file.write(json.dumps(session_start) + '\n')
         log_file.flush()
         log_file.close()
 

--- a/flor/logs_manipulator/open_log.py
+++ b/flor/logs_manipulator/open_log.py
@@ -1,10 +1,16 @@
-from flor.constants import *
-from flor.face_library.flog import Flog
-from flor.utils import cond_mkdir, refresh_tree, cond_rmdir
-from flor.stateful import get, put, start
-import os
 import datetime
 import json
+import re
+import uuid
+
+import git
+import boto3
+
+from flor.constants import *
+from flor.face_library.flog import Flog
+from flor.stateful import put, start
+from flor.utils import cond_mkdir, refresh_tree, cond_rmdir
+
 
 class OpenLog:
 
@@ -21,7 +27,43 @@ class OpenLog:
             put('depth_limit', depth_limit)
 
         session_start = {'session_start': format(datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S'))}
-        log_file.write(json.dumps(session_start) + '\n')
+
+        # MAC address
+        MAC_addr = {'MAC_address': ':'.join(re.findall('..?', '{:x}'.format(uuid.getnode())))}
+
+        to_write = [session_start, MAC_addr]
+
+        # Get EC2 instance type
+        try:
+            ec2 = boto3.resource('ec2')
+            for i in ec2.instances.all():
+                to_write.append({'EC2_instance_type': i.instance_type})
+        except:
+            to_write.append({'EC2_instance_type': 'None'})
+
+        # User info from Git
+        class GitConfig(git.Repo):
+            def __init__(self, *args, **kwargs):
+                #
+                # Work around the GitPython issue #775
+                # https://github.com/gitpython-developers/GitPython/issues/775
+                #
+                self.git_dir = os.path.join(os.getcwd(), ".git")
+                git.Repo.__init__(self, *args, **kwargs)
+
+        r = GitConfig().config_reader()
+        user_name = r.get_value('user', 'name')
+        user_email = r.get_value('user', 'email')
+        to_write.append({'git_user_name': user_name})
+        to_write.append({'git_user_email': user_email})
+
+        # System's userid
+        import getpass
+        user_id = getpass.getuser()
+        to_write.append({'user_id': user_id})
+
+        for x in to_write:
+            log_file.write(json.dumps(x) + '\n')
         log_file.flush()
         log_file.close()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ ipykernel
 notebook
 conda
 cytoolz
+boto3


### PR DESCRIPTION
Collect and log more contexts during execution:

- MAC address from the machine
- If EC2 instance, get instance type
- User info from Git
- System's userid
- Reliable timestamp from time.nist.gov

Also, pyflor_uninstall now removes the flor() script from shell config files.