### PR TITLE
Transformer & ETL bug fix

### DIFF
--- a/flor/complete_capture/transformer/transformer.py
+++ b/flor/complete_capture/transformer/transformer.py
@@ -149,7 +149,10 @@ class Transformer(ast.NodeTransformer):
                                 isinstance(value.targets[0], ast.Name) and \
                                 value.targets[0].id == '__all__' and \
                                 'dir()' in astor.to_source(value.value):
-                            value.value.generators[0].ifs = [ast.parse(astor.to_source(value.value.generators[0].ifs[0]).replace('\n', '') + "and s != 'flog'").body[0].value]
+                            value.value.generators[0].ifs = [
+                                ast.parse(astor.to_source(value.value.generators[0].ifs[0]).replace('\n', '')
+                                          + "and {} != 'flog'".format(value.value.generators[0].target.id)).body[0].value
+                            ]
                         # OUTPUT ASSIGN STATEMENT
                         value = self.visit(Assign(value, self.relative_counter).parse())
                         new_values.append(value)

--- a/flor/log_scanner/scanner.py
+++ b/flor/log_scanner/scanner.py
@@ -1,4 +1,5 @@
 import json
+import copy
 
 from .state_machines.actual_param import ActualParam
 from .state_machines.root_expression import RootExpression
@@ -182,10 +183,17 @@ class Scanner:
         """
         rows = []
         row = []
+        cols = set()
         for each in self.collected:
             k = list(each.keys()).pop()
             if k not in map(lambda x: list(x.keys()).pop(), row):
                 row.append(each)
+                if k not in cols:
+                    cols.add(k)
+                    none_copy = copy.deepcopy(each)
+                    none_copy[k][list(each[k].keys())[0]] = None
+                    for x in rows:
+                        x.append(none_copy)
             else:
                 rows.append(row)
                 new_row = []


### PR DESCRIPTION
- Fixed `to_rows()` to get rid of the "ValueError: arrays must all be same length" error when there are annotations that come after loops
- More general fix of the bug with wildcard imports trying to import `flog`